### PR TITLE
bugfix: cast clock skew var before calculations

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -641,8 +641,8 @@ class OpenIDConnect(object):
             return False
 
         # step 10: check iat
-        if id_token['iat'] < (time.time() -
-                              current_app.config['OIDC_CLOCK_SKEW']):
+        if int(id_token['iat']) < (int(time.time()) -
+                              int(current_app.config['OIDC_CLOCK_SKEW'])):
             logger.error('Token issued in the past')
             return False
 


### PR DESCRIPTION
The OIDC_CLOCK_SKEW variable is defaulted to 60 seconds as an integer, but when provided as a environment variable this is to be considered a string. I propose the following patch, which was tested on a live system that solved the bug.